### PR TITLE
fix base directory names in build.sh

### DIFF
--- a/images/build.sh
+++ b/images/build.sh
@@ -1,4 +1,4 @@
 #!/bin/bash
 
-(cd challenge_base && docker build -t gcr.io/paradigmxyz/ctf/base:latest .)
-(cd eth_challenge_base && docker build -t gcr.io/paradigmxyz/ctf/eth-base:latest .)
+(cd challenge-base && docker build -t gcr.io/paradigmxyz/ctf/base:latest .)
+(cd eth-challenge-base && docker build -t gcr.io/paradigmxyz/ctf/eth-base:latest .)


### PR DESCRIPTION
`build.sh` - directory names were not correct causing errors when building via cli. They have been corrected. 