### PR TITLE
fix kill instance url

### DIFF
--- a/paradigmctf.py/ctf_launchers/launcher.py
+++ b/paradigmctf.py/ctf_launchers/launcher.py
@@ -139,7 +139,7 @@ class Launcher(abc.ABC):
         return 0
 
     def kill_instance(self) -> int:
-        resp = requests.delete(f"{ORCHESTRATOR_HOST}/instances/${self.get_instance_id()}")
+        resp = requests.delete(f"{ORCHESTRATOR_HOST}/instances/{self.get_instance_id()}")
         body = resp.json()
 
         print(body["message"])


### PR DESCRIPTION
delete the extra `$` symbol from the URL to resolve the issue of being unable to delete instances.